### PR TITLE
Fixes an iOS bug when building with Unity 5.4.0b22

### DIFF
--- a/Assets/GoogleDrive/GoogleDriveAuthorization.cs
+++ b/Assets/GoogleDrive/GoogleDriveAuthorization.cs
@@ -416,10 +416,10 @@ partial class GoogleDrive
 		var webView = obj.AddComponent<WebViewObject>();
 		webView.url = AuthorizationURL;
 
-		while (webView.token == null && !webView.cancelled)
+		while (webView.GetToken() == null && !webView.GetCancelled())
 			yield return null;
 
-		if (webView.cancelled)
+		if (webView.GetCancelled())
 		{
 			GameObject.Destroy(obj);
 
@@ -429,7 +429,7 @@ partial class GoogleDrive
 			yield break;
 		}
 
-		authorizationCode = webView.token;
+		authorizationCode = webView.GetToken();
 
 		GameObject.Destroy(obj);
 		#endregion

--- a/Assets/GoogleDrive/WebViewObject.cs
+++ b/Assets/GoogleDrive/WebViewObject.cs
@@ -17,12 +17,12 @@ public class WebViewObject : MonoBehaviour
 	/// <summary>
 	/// Authorization code.
 	/// </summary>
-	public string token = null;
+	string token = null;
 
 	/// <summary>
 	/// WebView closed by user touch.
 	/// </summary>
-	public bool cancelled = false;
+	bool cancelled = false;
 
 	IntPtr webView;
 
@@ -41,6 +41,16 @@ public class WebViewObject : MonoBehaviour
 
 		StartCoroutine(CheckTitle());
 	}
+
+  public string GetToken()
+  {
+    return this.token;
+  }
+
+  public string GetCancelled()
+  {
+    return this.cancelled;
+  }
 
 	/// <summary>
 	/// Authorization result will be shown in title.


### PR DESCRIPTION
```
Type '[Assembly-CSharp]WebViewObject' has an extra field 'token' of type 'System.String' in the player and thus can't be serialized
Type '[Assembly-CSharp]WebViewObject' has an extra field 'cancelled' of type 'System.Boolean' in the player and thus can't be serialized
Fields serialized in Editor, class 'WebViewObject'
Fields serialized in target platform, class 'WebViewObject'
    'token' of type 'System.String'
    'cancelled' of type 'System.Boolean'
```

Fixes #11 .
